### PR TITLE
Update Distributor.sol

### DIFF
--- a/src/Distributor.sol
+++ b/src/Distributor.sol
@@ -112,9 +112,11 @@ contract Distributor is Initializable, PausableUpgradeable, ReentrancyGuardUpgra
 
     couponAmountToDistribute -= shares;
     bondToken.resetIndexedUserAssets(msg.sender, isLastAuctionFinalized);
-    IERC20(couponToken).safeTransfer(msg.sender, shares);
 
     emit ClaimedShares(msg.sender, currentPeriod, shares);
+
+    IERC20(couponToken).safeTransfer(msg.sender, shares);
+
   }
 
   /**


### PR DESCRIPTION
Moved the emit `ClaimedShares` statement after updating internal state but before the external token transfer to ensure accurate event logging only after successful state changes, maintaining consistency and safety